### PR TITLE
Update Big_Wheel_Macro_Pad_Firmware.ino

### DIFF
--- a/Big_Wheel_Macro_Pad_Firmware/Big_Wheel_Macro_Pad_Firmware.ino
+++ b/Big_Wheel_Macro_Pad_Firmware/Big_Wheel_Macro_Pad_Firmware.ino
@@ -112,7 +112,7 @@ void queueAction(int action) {
   Serial.println(action);
 #endif
 
-  if (action != NO_ACTION && actionIndex < 7) {
+  if (action != NO_ACTION && actionIndex < 6) {
     allActionsThisFrame[actionIndex] = action;
     actionIndex++;
   }


### PR DESCRIPTION
Changed the max value that the actionIndex can reach from 6, to 5.

This would cause a crash if more than 6 actions during a frame since the code would try to write a seventh value to a 6 element array